### PR TITLE
Add support for creating multiple jobs

### DIFF
--- a/client/src/JobClient.ts
+++ b/client/src/JobClient.ts
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 import { STATUS } from "./constants";
-class StatusClient {
+class JobClient {
   private baseUrl: string;
 
   constructor(baseUrl: string) {
@@ -77,4 +77,4 @@ class StatusClient {
   }
 }
 
-export { StatusClient };
+export { JobClient };

--- a/client/src/JobClient.ts
+++ b/client/src/JobClient.ts
@@ -7,6 +7,29 @@ class JobClient {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
   }
 
+  public async createJob(
+    processingDuration: number,
+    shouldError: boolean
+  ): Promise<CreateJobResponse> {
+    const response = await fetch(`${this.baseUrl}/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        processing_duration: processingDuration,
+        should_error: shouldError,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to create job: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const data = await response.json() as CreateJobResponse;
+    return { job_id: data.job_id, status: data.status };
+  }
+
   /**
    * Fetches the current status of the job from the server.
    * @returns {Promise<string>} The current status of the job as a string.

--- a/client/src/JobClient.ts
+++ b/client/src/JobClient.ts
@@ -7,6 +7,13 @@ class JobClient {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
   }
 
+  /**
+   * Creates a new job on the server with the specified parameters.
+   * @param {number} processingDuration - The time in seconds the job should take before completing or erroring.
+   * @param {boolean} shouldError - Whether the job should end in an error state (true) or complete successfully (false).
+   * @returns {Promise<{ job_id: string; status: string }>} An object containing the newly created job_id and its initial status.
+   * @throws {Error} If the HTTP request fails or the server returns an error response.
+   */
   public async createJob(
     processingDuration: number,
     shouldError: boolean

--- a/client/src/JobClient.ts
+++ b/client/src/JobClient.ts
@@ -66,7 +66,8 @@ class JobClient {
    */
   public async awaitCompletion(
     timeoutMs: number = 30000,
-    pollIntervalMs: number = 1000
+    pollIntervalMs: number = 1000,
+    jobId: string
   ): Promise<string> {
     const start = Date.now();
 
@@ -81,7 +82,7 @@ class JobClient {
       let status: string;
       try {
         console.log("Fetching status...");
-        status = await this.getStatus();
+        status = await this.getStatus(jobId);
       } catch (err: unknown) {
         // For now, decide to fail immediately TODO: Add retry logic/handle errors
         throw new Error(`Failed to fetch status: ${err}`);

--- a/client/src/JobClient.ts
+++ b/client/src/JobClient.ts
@@ -26,20 +26,23 @@ class JobClient {
       );
     }
 
-    const data = await response.json() as CreateJobResponse;
+    const data = (await response.json()) as CreateJobResponse;
     return { job_id: data.job_id, status: data.status };
   }
 
   /**
    * Fetches the current status of the job from the server.
+   * @param {string} jobId - The unique identifier of the job to check.
    * @returns {Promise<string>} The current status of the job as a string.
    * @throws {Error} If the HTTP request fails or the server responds with an error status.
    */
-  public async getStatus(): Promise<string> {
-    const response = await fetch(`${this.baseUrl}/status`);
+  public async getStatus(jobId: string): Promise<string> {
+    const response = await fetch(
+      `${this.baseUrl}/status?job_id=${encodeURIComponent(jobId)}`
+    );
     if (!response.ok) {
       throw new Error(
-        `Failed to fetch status: ${response.status} ${response.statusText}`
+        `Failed to fetch status for job ${jobId}: ${response.status} ${response.statusText}`
       );
     }
 

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,1 +1,1 @@
-export { StatusClient } from './StatusClient';  
+export { JobClient } from './JobClient';  

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -1,5 +1,10 @@
-type resultType = 'pending' | 'completed' | 'error';
+type resultType = "pending" | "completed" | "error";
 
 interface StatusResponse {
-    result: resultType;
-  }
+  result: resultType;
+}
+
+interface CreateJobResponse {
+  job_id: string;
+  status: resultType;
+}

--- a/client/tests/test-client.ts
+++ b/client/tests/test-client.ts
@@ -6,9 +6,14 @@ async function runTest() {
   const client = new JobClient(BASE_URL);
 
   try {
+    console.log("Creating a new job...");
+    // Create a job that takes 10 seconds and does not error
+    const { job_id, status } = await client.createJob(10, false);
+    console.log(`Job created with ID: ${job_id}, initial status: ${status}`);
+
     console.log("Waiting for job completion...");
-    const finalStatus = await client.awaitCompletion();
-    console.log(`Final job status: ${finalStatus}`);
+    const finalStatus = await client.awaitCompletion(30000, 1000, job_id);
+    console.log(`Final job status for job ${job_id}: ${finalStatus}`);
   } catch (error) {
     console.error("Error while waiting for job completion:", error);
   }

--- a/client/tests/test-client.ts
+++ b/client/tests/test-client.ts
@@ -1,9 +1,9 @@
-import { StatusClient } from "../src";
+import { JobClient } from "../src";
 
 const BASE_URL: string = "http://localhost:8000";
 
 async function runTest() {
-  const client = new StatusClient(BASE_URL);
+  const client = new JobClient(BASE_URL);
 
   try {
     console.log("Waiting for job completion...");

--- a/server/core/state.py
+++ b/server/core/state.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from .task import Task
+
+
+class TaskRegistry:
+    def __init__(self):
+        self.tasks: Dict[str, Task] = {}
+
+    def add_task(self, task: Task):
+        self.tasks[task.job_id] = task
+
+    def get_task(self, job_id: str) -> Task:
+        return self.tasks.get(job_id)

--- a/server/core/task.py
+++ b/server/core/task.py
@@ -1,0 +1,30 @@
+import time
+import uuid
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TaskStatus:
+    PENDING = "pending"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+class Task:
+    def __init__(self, processing_duration: float, should_error: bool = False):
+        self.job_id = str(uuid.uuid4())
+        self.start_time = time.time()
+        self.processing_duration = processing_duration
+        self.should_error = should_error
+        self._status = TaskStatus.PENDING  
+
+    def get_status(self):
+        if self._status in [TaskStatus.COMPLETED, TaskStatus.ERROR]:
+            return self._status
+
+        elapsed = time.time() - self.start_time
+        if elapsed >= self.processing_duration:
+            if self.should_error:
+                self._status = TaskStatus.ERROR
+            else:
+                self._status = TaskStatus.COMPLETED
+        return self._status

--- a/server/main.py
+++ b/server/main.py
@@ -1,11 +1,13 @@
 from fastapi import FastAPI
 from server.routers.reset import router as reset_router
 from server.routers.status import router as status_router
-from server.core.config import config
+from server.core.state import TaskRegistry
+from server.routers.jobs import router as jobs_router
+
 app = FastAPI()
 
-# Shared state between endpoints
-app.state.config = config
+app.state.task_registry = TaskRegistry()
 
 app.include_router(reset_router)
 app.include_router(status_router)
+app.include_router(jobs_router)

--- a/server/routers/jobs.py
+++ b/server/routers/jobs.py
@@ -1,4 +1,3 @@
-# server/routers/jobs.py
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 from server.core.task import Task

--- a/server/routers/jobs.py
+++ b/server/routers/jobs.py
@@ -1,0 +1,20 @@
+# server/routers/jobs.py
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+from server.core.task import Task
+
+router = APIRouter()
+
+
+class CreateJobRequest(BaseModel):
+    processing_duration: float
+    should_error: bool
+
+
+@router.post("/jobs")
+def create_job(req: Request, body: CreateJobRequest):
+    task = Task(
+        processing_duration=body.processing_duration, should_error=body.should_error
+    )
+    req.app.state.task_registry.add_task(task)
+    return {"job_id": task.job_id, "status": task.get_status()}

--- a/server/routers/status.py
+++ b/server/routers/status.py
@@ -1,28 +1,26 @@
-import time
-
-from fastapi import APIRouter, Request
-from server.routers.utils import get_job_start_time, get_processing_duration
 import asyncio
+import time
+from fastapi import APIRouter, Request, HTTPException, Query
+from server.core.state import TaskRegistry
+from server.core.task import TaskStatus
 
 router = APIRouter()
 
-
 @router.get("/status")
-async def get_status(request: Request):
-    """Endpoint to check the status of the job."""
-    job_start_time = get_job_start_time(request)
-    processing_duration = get_processing_duration(request)
+async def get_status(request: Request, job_id: str = Query(...)):
+    registry: TaskRegistry = request.app.state.task_registry
+    task = registry.get_task(job_id)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task with job_id {job_id} not found")
 
     long_poll_timeout = 5.0
     poll_interval = 0.5
-
     start_wait = time.time()
 
     while time.time() - start_wait < long_poll_timeout:
-        elapsed = time.time() - job_start_time
-        if elapsed >= processing_duration:
-            return {"result": "completed"}
-
+        status = task.get_status()
+        if status in [TaskStatus.COMPLETED, TaskStatus.ERROR]:
+            return {"result": status}
         await asyncio.sleep(poll_interval)
 
-    return {"result": "pending"}
+    return {"result": TaskStatus.PENDING}


### PR DESCRIPTION
### Description

**Summary:**  
This PR enhances the backend to support multiple tasks and updates the client to emulate a more realistic usage of a client library with job creation and status polling.  

**Details:**  
- **Server**:  
   - Introduced a `TaskRegistry` class to manage multiple tasks in memory.  
   - The `TaskRegistry` is shared across the application state to handle job lifecycles efficiently.  
   - Added a new **`POST /jobs` endpoint** that allows clients to create new jobs. This endpoint returns a unique **job ID** (UUID) that can be used for polling the job status.  
- **Client**:  
   - Added a `createJob()` method to the `JobClient` class, which sends a `POST` request to the `/jobs` endpoint to create a new job.  
   - The returned job ID can then be used to poll for the status of the created job.  
- **Testing**:  
   - Updated the existing simple test script to showcase the end-to-end functionality of job creation and status polling.  
